### PR TITLE
Fix height rounding in raw export

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ To update your add-on, please remove the old version and install the new version
 Verified Compatibility
 | Add-on Version | Blender Versions |
 | --------------- | --------------- |
+| 1.4.1           | 3.3             |
 | 1.4             | 3.3             |
 | 1.3             | 3.3             |
 | 1.2             | 3.3             |


### PR DESCRIPTION
Any height too close to the top height is set to 0 height

Fixes #6 

After fix:
![zero_fixed](https://github.com/user-attachments/assets/8fe86fd9-2365-43ab-af9e-558c8df4dd27)
